### PR TITLE
Fix unsoundness (by yeeting unsafe)

### DIFF
--- a/enum-collections-macros/src/lib.rs
+++ b/enum-collections-macros/src/lib.rs
@@ -34,7 +34,7 @@ pub fn enum_collections(_args: TokenStream, input: TokenStream) -> TokenStream {
                 self as usize
             }
 
-            fn len() -> usize{
+            const fn len() -> usize{
                 #enum_count
             }
 

--- a/enum-collections/src/enummap/index.rs
+++ b/enum-collections/src/enummap/index.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, IndexMut};
 
 use crate::{EnumMap, Enumerated};
 
-impl<'a, K, V> Index<K> for EnumMap<'a, K, V>
+impl<K, V> Index<K> for EnumMap<K, V>
 where
     K: Enumerated,
     V: Default,
@@ -14,7 +14,7 @@ where
     }
 }
 
-impl<'a, K, V> IndexMut<K> for EnumMap<'a, K, V>
+impl<K, V> IndexMut<K> for EnumMap<K, V>
 where
     K: Enumerated,
     V: Default,

--- a/enum-collections/src/enumtable/index.rs
+++ b/enum-collections/src/enumtable/index.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, IndexMut};
 
 use crate::{EnumTable, Enumerated};
 
-impl<'a, K, V> Index<K> for EnumTable<'a, K, V>
+impl<K, V> Index<K> for EnumTable<K, V>
 where
     K: Enumerated,
     V: Default,
@@ -14,7 +14,7 @@ where
     }
 }
 
-impl<'a, K, V> IndexMut<K> for EnumTable<'a, K, V>
+impl<K, V> IndexMut<K> for EnumTable<K, V>
 where
     K: Enumerated,
     V: Default,


### PR DESCRIPTION
## Problem
Running `cargo miri test` shows that the current usage of unsafe is unsound.
One of the issues is that when initializing the backing array, the array is created
pointing to uninitialized memory, which is always unsound. The backing slice
needs to be initialized first (`MaybeUninit` can be used for that purpose).

```rust
struct HasDrop(Box<u8>);
impl Default for HasDrop {
    fn default() -> Self {
        Self(Box::new(0))
    }
}
impl Drop for HasDrop {
    fn drop(&mut self) {
        *self.0 = 42;
    }
}
// Segmentation Vault
EnumTable::<Letter, HasDrop>::new();
```

Additionally, `EnumMap` assumes that `None` is always represented by zero:
```rust
// Panics
assert_eq!(None, EnumMap::<Letter, char>::new().get(Letter::A));
```

Also (this isn't a soundness issue) the `'a` livetime was meaningless, as it can be arbitrarily chosen – a pointer instead of 
a reference would have sufficed; a reference doesn't properly represent the ownership semantics here.

## Solution
Replace reference with an owning pointer, remove all usages of unsafe.