### PR TITLE
Discriminant

### DIFF
--- a/enum-collections-macros/Cargo.toml
+++ b/enum-collections-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-collections-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 description = "Macros to make EnumCollections easy to use"
@@ -18,3 +18,4 @@ proc-macro = true
 
 [dependencies]
 syn = "1.0"
+quote = "1.0"

--- a/enum-collections-macros/Cargo.toml
+++ b/enum-collections-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-collections-macros"
-version = "0.4.0"
+version = "0.3.0"
 edition = "2021"
 
 description = "Macros to make EnumCollections easy to use"

--- a/enum-collections/Cargo.toml
+++ b/enum-collections/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["data-structures"]
 documentation = "https://docs.rs/enum-collections"
 
 [dependencies]
-enum-collections-macros = "0.2.0"
+enum-collections-macros = "0.4.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/enum-collections/Cargo.toml
+++ b/enum-collections/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["data-structures"]
 documentation = "https://docs.rs/enum-collections"
 
 [dependencies]
-enum-collections-macros = "0.4.0"
+enum-collections-macros = { path = "../enum-collections-macros", version = "0.3.0" }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/enum-collections/src/enummap/mod.rs
+++ b/enum-collections/src/enummap/mod.rs
@@ -13,7 +13,7 @@ use crate::Enumerated;
 /// Using `get` and `insert` functions.
 ///
 /// ```
-/// use enum_collections::{enum_collections, EnumMap, Enumerated};
+/// use enum_collections::{EnumMap, Enumerated};
 /// #[derive(Enumerated)]
 /// enum Letter {
 ///     A,
@@ -111,6 +111,7 @@ mod tests {
         A,
         B,
     }
+
     #[test]
     fn new_all_none() {
         let enum_map = EnumMap::<Letter, i32>::new();

--- a/enum-collections/src/enumtable/mod.rs
+++ b/enum-collections/src/enumtable/mod.rs
@@ -21,7 +21,7 @@ use crate::Enumerated;
 ///
 /// Using get and insert functions.
 /// ```
-/// use enum_collections::{enum_collections, EnumTable, Enumerated};
+/// use enum_collections::{EnumTable, Enumerated};
 /// #[derive(Enumerated)]
 /// enum Letter {
 ///     A,

--- a/enum-collections/src/lib.rs
+++ b/enum-collections/src/lib.rs
@@ -5,7 +5,6 @@ mod enumtable;
 pub use crate::enumerated::Enumerated;
 pub use crate::enummap::EnumMap;
 pub use crate::enumtable::EnumTable;
-pub use enum_collections_macros::enum_collections;
 pub use enum_collections_macros::Enumerated;
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
The data structures rely on the enum variants starting at 0 and increasing by one each time. This is the default, but not always the case. For example, using
```rust
#[derive(Enumerable)] Foo { Bar = 42 }
```
will lead to a index out of bounds panic.

## Solution
Don't allow custom discriminants.
Note that this PR branches off of #1 