### PR TITLE
Array of variants & from_fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Using `get` and `insert` functions.
      A,
      B,
  }
-
+ assert_eq!(Letter::VARIANTS.len(), 2); // VARIANTS provided by this crate
+ 
  let mut map: EnumMap<Letter, u8> = EnumMap::new();
  map.insert(Letter::A, 42);
  assert_eq!(Some(&42u8), map.get(Letter::A));
@@ -60,6 +61,7 @@ Using Index and IndexMut syntactic sugar.
      A,
      B,
  }
+ assert_eq!(Letter::VARIANTS.len(), 2); // VARIANTS provided by this crate
 
  let mut map: EnumTable<Letter, u8> = EnumTable::new();
  map[Letter::A] = 42;

--- a/enum-collections-macros/Cargo.toml
+++ b/enum-collections-macros/Cargo.toml
@@ -19,3 +19,4 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+proc-macro2 = "1.0"

--- a/enum-collections-macros/src/lib.rs
+++ b/enum-collections-macros/src/lib.rs
@@ -15,7 +15,8 @@ pub fn derive_enum_collections(input: TokenStream) -> TokenStream {
             }
             .into();
     };
-    let enum_count = en.variants.iter().count();
+
+    let mut variants = proc_macro2::TokenStream::new();
 
     for variant in en.variants {
         if let Some((_, discriminant)) = variant.discriminant {
@@ -24,6 +25,8 @@ pub fn derive_enum_collections(input: TokenStream) -> TokenStream {
             }
             .into();
         }
+        let variant_name = variant.ident;
+        variants.extend(quote! { Self::#variant_name, });
     }
 
     quote! {
@@ -33,10 +36,7 @@ pub fn derive_enum_collections(input: TokenStream) -> TokenStream {
                 self as usize
             }
 
-            fn len() -> usize{
-                #enum_count
-            }
-
+            const VARIANTS: &'static [Self] = &[#variants];
         }
     }
     .into()

--- a/enum-collections/src/enumerated.rs
+++ b/enum-collections/src/enumerated.rs
@@ -10,9 +10,9 @@
 ///     B,
 /// }
 /// ```
-pub trait Enumerated {
+pub trait Enumerated: Sized + 'static {
     /// Maps an enum to a unique position in an array.
     fn position(self) -> usize;
-    /// Total number of values in an Enum.
-    fn len() -> usize;
+    // All variants of this enum.
+    const VARIANTS: &'static [Self];
 }

--- a/enum-collections/src/enumerated.rs
+++ b/enum-collections/src/enumerated.rs
@@ -9,6 +9,8 @@
 ///     A,
 ///     B,
 /// }
+///
+/// assert_eq!(Letter::VARIANTS.len(), 2);
 /// ```
 pub trait Enumerated: Sized + 'static {
     /// Maps an enum to a unique position in an array.

--- a/enum-collections/src/enummap/mod.rs
+++ b/enum-collections/src/enummap/mod.rs
@@ -58,7 +58,7 @@ where
     /// no resizing is further required.
     pub fn new() -> Self {
         Self {
-            values: (0..K::len()).map(|_| None).collect::<Vec<_>>().into(),
+            values: K::VARIANTS.iter().map(|_| None).collect::<Vec<_>>().into(),
             _key_phantom_data: PhantomData {},
         }
     }
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn new_all_none() {
         let enum_map = EnumMap::<Letter, i32>::new();
-        for index in 0..Letter::len() {
+        for index in 0..Letter::VARIANTS.len() {
             assert_eq!(None, enum_map.values[index]);
         }
     }

--- a/enum-collections/src/enumtable/mod.rs
+++ b/enum-collections/src/enumtable/mod.rs
@@ -51,7 +51,8 @@ where
     /// no resizing is further required. All values are initialized with `V`'s [Default] value.
     pub fn new() -> Self {
         Self {
-            values: (0..K::len())
+            values: K::VARIANTS
+                .iter()
                 .map(|_| V::default())
                 .collect::<Vec<V>>()
                 .into(),
@@ -133,7 +134,7 @@ mod tests {
     #[test]
     fn new_all_default() {
         let enum_table = EnumTable::<Letter, Value>::new();
-        for index in 0..Letter::len() {
+        for index in 0..Letter::VARIANTS.len() {
             assert_eq!(Value::default(), enum_table.values[index]);
         }
     }

--- a/enum-collections/src/lib.rs
+++ b/enum-collections/src/lib.rs
@@ -21,7 +21,7 @@ mod tests {
 
         assert_eq!(0, Letter::A.position());
         assert_eq!(1, Letter::B.position());
-        assert_eq!(2, Letter::len());
+        assert_eq!(2, Letter::VARIANTS.len());
     }
 
     #[test]
@@ -34,6 +34,6 @@ mod tests {
 
         assert_eq!(0, Letter::A.position());
         assert_eq!(1, Letter::B.position());
-        assert_eq!(2, Letter::len());
+        assert_eq!(2, Letter::VARIANTS.len());
     }
 }


### PR DESCRIPTION
Provides a slice containing all variants of an enum as an associated constant.
Also uses this to implement `from_fn` for `EnumTable`, which is useful when
creating a table with different values than the default value and makes it
possible to use `EnumTables` with values that don't implement `Default`.

Note that this is branched off of #5