### PR TITLE
feat: Implement Eq and PartialEq for EnumTable and EnumMap

### DIFF
--- a/enum-collections-macros/src/lib.rs
+++ b/enum-collections-macros/src/lib.rs
@@ -10,10 +10,10 @@ pub fn derive_enum_collections(input: TokenStream) -> TokenStream {
     let generics = &input.generics;
     let name = &input.ident;
     let syn::Data::Enum(en) = input.data else {
-            return quote_spanned! {
-                input.span() => compile_error!("The `Enumerated` macro only supports enums.");
-            }
-            .into();
+        return quote_spanned! {
+            input.span() => compile_error!("The `Enumerated` macro only supports enums.");
+        }
+        .into();
     };
 
     let mut variants = proc_macro2::TokenStream::new();

--- a/enum-collections/src/enummap.rs
+++ b/enum-collections/src/enummap.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+use std::ops::{Deref, Index, IndexMut};
 
 use crate::Enumerated;
 
@@ -140,6 +140,23 @@ where
     }
 }
 
+impl<K, V> PartialEq<Self> for EnumMap<K, V>
+where
+    K: Enumerated,
+    V: Default + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.values.deref().eq(other.values.deref())
+    }
+}
+
+impl<K, V> Eq for EnumMap<K, V>
+where
+    K: Enumerated,
+    V: Default + Eq,
+{
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Enumerated;
@@ -194,5 +211,16 @@ mod tests {
         let debug_output = format!("{enum_map:?}");
         let expected_output = "{A: Some(42), B: None}";
         assert_eq!(expected_output, debug_output);
+    }
+
+    #[test]
+    fn eq() {
+        let mut first_map = EnumMap::<LetterDebugDerived, i32>::new();
+        first_map.insert(LetterDebugDerived::A, 42);
+        let mut second_map = EnumMap::<LetterDebugDerived, i32>::new();
+        second_map.insert(LetterDebugDerived::A, 42);
+        assert_eq!(first_map, second_map);
+        second_map.insert(LetterDebugDerived::B, 0);
+        debug_assert_ne!(first_map, second_map);
     }
 }

--- a/enum-collections/src/enumtable.rs
+++ b/enum-collections/src/enumtable.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+use std::ops::{Deref, Index, IndexMut};
 
 use crate::Enumerated;
 
@@ -123,6 +123,23 @@ where
     }
 }
 
+impl<K, V> PartialEq<Self> for EnumTable<K, V>
+where
+    K: Enumerated,
+    V: Default + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.values.deref().eq(other.values.deref())
+    }
+}
+
+impl<K, V> Eq for EnumTable<K, V>
+where
+    K: Enumerated,
+    V: Default + Eq,
+{
+}
+
 #[cfg(test)]
 mod tests {
     use super::EnumTable;
@@ -187,5 +204,16 @@ mod tests {
         let debug_output = format!("{enum_table:?}");
         let expected_output = "{A: 42, B: 0}";
         assert_eq!(expected_output, debug_output);
+    }
+
+    #[test]
+    fn eq() {
+        let mut first_table = EnumTable::<LetterDebugDerived, i32>::new();
+        first_table[LetterDebugDerived::A] = 42;
+        let mut second_table = EnumTable::<LetterDebugDerived, i32>::new();
+        second_table[LetterDebugDerived::A] = 42;
+        assert_eq!(first_table, second_table);
+        second_table[LetterDebugDerived::B] = 42;
+        debug_assert_ne!(first_table, second_table);
     }
 }


### PR DESCRIPTION
Positions of keys are always the same, because the underlying array always has the same layout. Therefore, values can be compared directly.

GH-13