### PR TITLE
feat: Debug and Eq implementations feature-flagged, enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Enum Collections for Rust
 [![Rust](https://github.com/Pscheidl/enum-map/actions/workflows/rust.yml/badge.svg)](https://github.com/Pscheidl/enum-map/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/crates/v/enum-collections)](https://crates.io/crates/enum-collections)
+[![docs.rs](https://img.shields.io/docsrs/enum-collections)](https://docs.rs/enum-collections/latest/enum_collections/)
 
 [Contribution guide](CONTRIBUTING.md) | [Apache v2 license](LICENSE)
 
@@ -70,6 +71,12 @@ Using Index and IndexMut syntactic sugar.
  assert_eq!(42u8, map[Letter::A]);
  assert_eq!(u8::default(), map[Letter::B]);
 ```
+
+## Features
+
+Portions of functionality are feature-flagged, but enabled by default. This is to allow turning this functionality off when not needed, e.g. `Debug` and `Eq` implementations.
+
+See [docs.rs](https://docs.rs/crate/enum-collections/latest/features) for details.
 
 ## Benchmarks
 

--- a/enum-collections/Cargo.toml
+++ b/enum-collections/Cargo.toml
@@ -12,6 +12,11 @@ keywords = ["collections", "hashmap", "hashtable", "enum", "enummap"]
 categories = ["data-structures"]
 documentation = "https://docs.rs/enum-collections"
 
+[features]
+default = ["debug", "eq"]
+debug = []
+eq = []
+
 [dependencies]
 enum-collections-macros = { path = "../enum-collections-macros", version = "0.3.0" }
 

--- a/enum-collections/src/enummap.rs
+++ b/enum-collections/src/enummap.rs
@@ -123,6 +123,7 @@ where
     }
 }
 
+#[cfg(feature = "debug")]
 impl<K, V> Debug for EnumMap<K, V>
 where
     K: Enumerated + Debug,
@@ -141,6 +142,7 @@ where
     }
 }
 
+#[cfg(feature = "eq")]
 impl<K, V> PartialEq<Self> for EnumMap<K, V>
 where
     K: Enumerated,
@@ -151,6 +153,7 @@ where
     }
 }
 
+#[cfg(feature = "eq")]
 impl<K, V> Eq for EnumMap<K, V>
 where
     K: Enumerated,
@@ -204,7 +207,7 @@ mod tests {
         A,
         B,
     }
-
+    #[cfg(feature = "debug")]
     #[test]
     fn debug() {
         let mut enum_map = EnumMap::<LetterDebugDerived, i32>::new();
@@ -214,6 +217,7 @@ mod tests {
         assert_eq!(expected_output, debug_output);
     }
 
+    #[cfg(feature = "eq")]
     #[test]
     fn eq() {
         let mut first_map = EnumMap::<LetterDebugDerived, i32>::new();

--- a/enum-collections/src/enumtable.rs
+++ b/enum-collections/src/enumtable.rs
@@ -106,6 +106,7 @@ where
     }
 }
 
+#[cfg(feature = "debug")]
 impl<K, V> Debug for EnumTable<K, V>
 where
     K: Enumerated + Debug,
@@ -124,6 +125,7 @@ where
     }
 }
 
+#[cfg(feature = "eq")]
 impl<K, V> PartialEq<Self> for EnumTable<K, V>
 where
     K: Enumerated,
@@ -134,6 +136,7 @@ where
     }
 }
 
+#[cfg(feature = "eq")]
 impl<K, V> Eq for EnumTable<K, V>
 where
     K: Enumerated,
@@ -198,6 +201,7 @@ mod tests {
         B,
     }
 
+    #[cfg(feature = "debug")]
     #[test]
     fn debug() {
         let mut enum_table = EnumTable::<LetterDebugDerived, i32>::new();
@@ -207,6 +211,7 @@ mod tests {
         assert_eq!(expected_output, debug_output);
     }
 
+    #[cfg(feature = "eq")]
     #[test]
     fn eq() {
         let mut first_table = EnumTable::<LetterDebugDerived, i32>::new();


### PR DESCRIPTION
To make it possible to turn those features off selectively when not needed. Enabled by default to cover most use cases.