### PR TITLE
refactor: doc(hidden) for the crate::Enumerated trait

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build
-      run: cargo build
-
     - name: Tests
-      run: cargo test
+      run: cargo test --all-features
     
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy --all-features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [Contribution guide](CONTRIBUTING.md) | [Apache v2 license](LICENSE)
 
 
-A map of enum variants to values. EnumMap is a fixed-size map, where each variant of the enum is mapped to a value. This implementation of EnumMap uses safe Rust only and is a a zero-cost abstraction over an array (**const-sized**), where the index of the array corresponds to the position of the variant in the enum.
+A map of enum variants to values. EnumMap is a fixed-size map, where each variant of the enum is mapped to a value. This implementation of EnumMap uses **safe Rust** only and is a a zero-cost abstraction over an array (**const-sized**), where the index of the array corresponds to the position of the variant in the enum.
 
 Because it is a thin wrapper over an array, it is stack-allocated by default. Simply `std::boxed::Box`ing it will move it to the heap, at the caller's discretion.
 

--- a/enum-collections/src/enumerated.rs
+++ b/enum-collections/src/enumerated.rs
@@ -12,6 +12,7 @@
 ///
 /// assert_eq!(Letter::SIZE, 2);
 /// ```
+#[doc(hidden)]
 pub trait Enumerated: Sized + 'static {
     /// Maps an enum to a unique position in an array.
     fn position(self) -> usize;


### PR DESCRIPTION
Only the macro under the same path must be exposed. The public `Enumerated` trait the macro implements needn't. It can be a source of confusion for downstream users.